### PR TITLE
Fixed broken indentation when using 'linenos' option

### DIFF
--- a/css/overrides.css
+++ b/css/overrides.css
@@ -11,11 +11,6 @@
   max-width: 800px;
 }
 
-/* for vertical scrollbar */
-.highlight pre code * {
-  white-space: nowrap;
-}
-
 .highlight pre {
   overflow-x: auto;
 }


### PR DESCRIPTION
Resolved [issue #2 - The "linenos" option in syntax highlighting breaks code indentation](https://github.com/linagora/openpaas-doc/issues/2).